### PR TITLE
only configure app insights if configuration exists

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,10 +40,12 @@ from backend.utils import (
 from azure.monitor.opentelemetry import configure_azure_monitor
 from opentelemetry import trace
 
-configure_azure_monitor(
-    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", ""),
-    enable_live_metrics = True
-)
+appinsights_conn_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
+if appinsights_conn_string:
+    configure_azure_monitor(
+        connection_string=appinsights_conn_string,
+        enable_live_metrics=True
+    )
 
 # Original code starts here
 


### PR DESCRIPTION
This pull request includes a small change to the `app.py` file to improve the configuration of Azure Monitor. The change ensures that the connection string for Application Insights is retrieved once and reused, simplifying the code and potentially improving performance.

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R43-R46): Added a check to ensure `appinsights_conn_string` is only used if it is present in the environment variables.